### PR TITLE
fix: 修复单选框组，没有给 v-model 时，可以多选的bug

### DIFF
--- a/src/yike-design/components/radio/ykRadioGroup.vue
+++ b/src/yike-design/components/radio/ykRadioGroup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { nextTick, ref, watch } from "vue";
 import ykRaido from "./ykRadio.vue";
 import ykSpace from "../space/YkSpace.vue";
 
@@ -43,10 +43,12 @@ const isSelect = (e: any) => {
 	selectChecks.value=e;
 }
 
-const emitValue = (e: any) => {
+const emitValue = async (e: any) => {
 	isSelect(e)
 	emits("update:modelValue", selectChecks.value);
 	emits("change", selectChecks.value);
+	await nextTick()
+	changeCheck()
 };
 
 //渲染check列表数组
@@ -55,7 +57,7 @@ const checks = ref();
 //判断元素是否初始化选中
 const defineSelect = (e:any):boolean => {
 	let back=false;
-	if (props.modelValue==e) {
+	if ( selectChecks.value == e ) {
 		back= true;
 	}
 	return back;
@@ -68,7 +70,7 @@ const gitCheck = () => {
 		for (var item of props.options) {
 			if (typeof item != "object") {
 				mod=defineSelect(item)
-				let data = { label: item, value: item,mod:mod };
+				let data = { label: item, value: item, mod: mod };
 				checks.value.push(data);
 			} else {
 				//判断某个属性是否在object中
@@ -100,10 +102,10 @@ const changeCheck=()=>{
 }
 
 //监听父级点击
-watch(props, () => {
-  selectChecks.value = props.modelValue;
-	changeCheck();
-});
+// watch(props, () => {
+//   selectChecks.value = props.modelValue;
+// 	changeCheck();
+// });
 </script>
 
 <template>

--- a/src/yike-design/components/radio/ykRadioGroup.vue
+++ b/src/yike-design/components/radio/ykRadioGroup.vue
@@ -5,7 +5,8 @@ import ykSpace from "../space/YkSpace.vue";
 
 const props = defineProps({
 	modelValue: {
-		type: [String,Number,Boolean]
+		type: [String,Number,Boolean],
+		default: undefined
 	},
 	options: {
 		type: Array,
@@ -43,12 +44,17 @@ const isSelect = (e: any) => {
 	selectChecks.value=e;
 }
 
+
+// 子级给组件传值，并通知父级
+// 如果父组件没有model值，则直接驱动视图更新
 const emitValue = async (e: any) => {
 	isSelect(e)
 	emits("update:modelValue", selectChecks.value);
 	emits("change", selectChecks.value);
-	await nextTick()
-	changeCheck()
+	if ( props.modelValue === undefined ) {
+		await nextTick()
+		changeCheck()
+	}
 };
 
 //渲染check列表数组
@@ -92,7 +98,7 @@ const gitCheck = () => {
 };
 gitCheck();
 
-//替换选项
+// 视图更新
 const changeCheck=()=>{
 	let mod:boolean;
 	for(let item of checks.value){
@@ -101,11 +107,11 @@ const changeCheck=()=>{
 	}
 }
 
-//监听父级点击
-// watch(props, () => {
-//   selectChecks.value = props.modelValue;
-// 	changeCheck();
-// });
+// 父级给组件传值，驱动视图更新
+watch(props, () => {
+  selectChecks.value = props.modelValue;
+	changeCheck();
+});
 </script>
 
 <template>


### PR DESCRIPTION
单选框组选项，第一个示例，没有给v-model，导致 props.modelValue 是 false, 导致每次点击都不会触发props的变动，导致可以多选的bug。
改用子级radio的值变动时，来触发一个数据更新和向上传递。