### PR TITLE
chore: remove pnpm in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "husky": "^8.0.0",
     "less": "^4.0.0",
     "lint-staged": "^13.2.3",
-    "pnpm": "^8.5.0",
     "postcss": "^8.4.27",
     "postcss-html": "^1.5.0",
     "postcss-less": "^6.0.0",


### PR DESCRIPTION
pnpm应由使用者`npm i -g pnpm`在本地全局安装，而非存在于项目开发依赖