### PR TITLE
Feature/base/add standard version

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -1,0 +1,65 @@
+{
+  "header": "# 更新日志 \n\n",
+  "types": [
+    {
+      "type": "feat",
+      "section": "✨ Features | 新功能",
+      "hidden": false
+    },
+    {
+      "type": "fix",
+      "section": "🐛 Bug Fixes | Bug 修复",
+      "hidden": false
+    },
+    {
+      "type": "init",
+      "section": "🎉 Init | 初始化",
+      "hidden": true
+    },
+    {
+      "type": "docs",
+      "section": "✏️ Documentation | 文档",
+      "hidden": false
+    },
+    {
+      "type": "style",
+      "section": "💄 Styles | 风格",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "♻️ Code Refactoring | 代码重构",
+      "hidden": true
+    },
+    {
+      "type": "perf",
+      "section": "⚡ Performance Improvements | 性能优化",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "✅ Tests | 测试",
+      "hidden": true
+    },
+    {
+      "type": "revert",
+      "section": "⏪ Revert | 回退",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "📦‍ Build System | 打包构建",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "🚀 Chore | 构建/工程依赖/工具",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "👷 Continuous Integration | CI 配置",
+      "hidden": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "new": "node ./config/script/new-component.mjs",
     "postinstall": "npx husky install",
     "preinstall": "npx only-allow pnpm",
-    "gen:icon": "pnpm --filter yike-design-ui gen:icon"
+    "gen:icon": "pnpm --filter yike-design-ui gen:icon",
+    "release": "standard-version"
   },
   "dependencies": {
     "svgo": "^3.0.2",
@@ -37,6 +38,7 @@
     "postcss-html": "^1.5.0",
     "postcss-less": "^6.0.0",
     "prettier": "^2.8.8",
+    "standard-version": "^9.5.0",
     "stylelint": "^15.10.1",
     "stylelint-config-recommended-vue": "^1.5.0",
     "stylelint-config-standard-vue": "^1.0.0",


### PR DESCRIPTION
使用standard-version自动生成版本和变更日志
这里我没有把生成的changelog.md传上来，附一张图

![image](https://github.com/ecaps1038/yike-design-dev/assets/39091494/65c5789a-d41e-4812-9ef9-caf4262ff3a2)

命令行使用情况
- --first-release 初次发布操作。这步操作并不会递进版本号。npx standard-version --first-release
- --prerelease 预发布操作。npx standard-version -- --prerelease 版本会从0.2.0变为0.2.0-0；npx standard-version -- --- prerelease alpha可以增加前序，版本会从0.2.0变为0.2.0-alpha.0。
- --release-as 指定发布操作。npx standard-version -- --release-as minor 版本从0.2.0变为0.3.0。

