### PR TITLE
feat(radio): 将 type属性作为props而不是HTML Attributes

### DIFF
--- a/demo/src/examples/radio/doc.md
+++ b/demo/src/examples/radio/doc.md
@@ -56,7 +56,7 @@
 | -------------- | -------------- | --------------------------- | ------ |
 | value(v-model) | 选中项绑定值   | number ｜ string ｜ boolean | --     |
 | label          | 单选框的值     | number ｜ string ｜ boolean | --     |
-| disabled       | 按钮是否被禁用 | false ｜ true               | false  |
+| disabled       | 按钮是否被禁用 | boolean                     | false  |
 
 #### Radio Slots
 
@@ -72,11 +72,14 @@
 
 #### RadioGroup Attributes
 
-| 参数     | 描述                   | 类型                   | 默认值  |
-| -------- | ---------------------- | ---------------------- | ------- |
-| theme    | 按钮单选框组的主题     | 'primary'｜'secondary' | primary |
-| size     | 按钮单选框组的尺寸     | false ｜ true          | false   |
-| disabled | 按钮单选框组是否被禁用 | false ｜ true          | false   |
+| 参数           | 描述                                          | 类型                        | 默认值       |
+| -------------- | --------------------------------------------- | --------------------------- | ------------ |
+| value(v-model) | 选中项绑定值                                  | number ｜ string ｜ boolean | --           |
+| theme          | 单选框组的主题 （仅当 type 为 button 时生效） | 'primary'｜'secondary'      | 'primary'    |
+| type           | 单选框组的类型                                | 'radio'｜'button'           | 'radio'      |
+| size           | 单选框组的尺寸（仅当 type 为 button 时生效）  | 's'｜ 'm'｜ 'l'｜'xl'       | 'l'          |
+| disabled       | 单选框组是否被禁用                            | boolean                     | false        |
+| direction      | 单选框的方向                                  | 'horizontal'｜'vertical'    | 'horizontal' |
 
 #### RadioGroup Slots
 

--- a/packages/yike-design-ui/src/components/radio/src/radio-group.ts
+++ b/packages/yike-design-ui/src/components/radio/src/radio-group.ts
@@ -5,6 +5,7 @@ export type RadioGroupProps = {
   modelValue?: number | string | boolean;
   size?: Size;
   theme?: 'primary' | 'secondary';
+  type?: 'radio' | 'button';
   disabled?: boolean;
   direction?: Direction;
 };

--- a/packages/yike-design-ui/src/components/radio/src/radio-group.vue
+++ b/packages/yike-design-ui/src/components/radio/src/radio-group.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="ykRadioGroupCls">
+  <div :class="ykRadioGroupCls" :type="type">
     <slot />
   </div>
 </template>
@@ -13,6 +13,7 @@ import '../style'
 const emits = defineEmits(radioGroupEmits)
 const props = withDefaults(defineProps<RadioGroupProps>(), {
   direction: 'horizontal',
+  type: 'radio',
 })
 
 const ykRadioGroupCls = computed(() => {


### PR DESCRIPTION
1. `radio-group` 组件可以通过传入 `type="button"` 将单选框组变为按钮形式。但当前的代码中 `radio-group` 并没有把 `type` 作为 props，而是通过属性透传来达成替换样式的目的，这也导致代码的可读性并不好（外部传入了 type 但组件代码中并没有显式地去使用它）。
2. 文档遗漏了几个 props 以及有些 props 的描述并不准确，也都一并修改了。