### PR TITLE
fix(input-number): 合并来自formItem 的表单尺寸

### DIFF
--- a/packages/yike-design-ui/src/components/input-number/src/input-number.vue
+++ b/packages/yike-design-ui/src/components/input-number/src/input-number.vue
@@ -3,7 +3,7 @@
     ref="inputRef"
     v-model="displayValue"
     :disabled="disabled"
-    :size="size"
+    :size="mergedSize"
     :class="bem()"
     v-bind="$attrs"
     @change="change"
@@ -15,10 +15,11 @@
     <template #suffix>
       <div
         v-show="!disabled && isHovering"
-        :class="[bem('buttons'), bem([size])]"
+        :class="[bem('buttons'), bem([mergedSize])]"
       >
         <YkButton
           :disabled="limit.isMax"
+          :size="mergedSize"
           type="secondary"
           @click="increase"
           @mousedown="startCombo(1)"
@@ -27,6 +28,7 @@
         </YkButton>
         <YkButton
           :disabled="limit.isMin"
+          :size="mergedSize"
           type="secondary"
           @click="decrease"
           @mousedown="startCombo(0)"
@@ -38,7 +40,7 @@
   </YkInput>
 </template>
 <script setup lang="ts">
-import { createCssScope } from '../../utils/bem'
+import { createCssScope, useFormItem } from '../../utils'
 import { YkInput, YkButton } from '../../../index'
 import { InputNumberProps } from './input-number'
 import { toRefs, ref, onMounted, reactive, computed } from 'vue'
@@ -58,6 +60,13 @@ const props = withDefaults(defineProps<InputNumberProps>(), {
 })
 
 const bem = createCssScope('input-number')
+
+const { size } = toRefs(props)
+
+const { mergedSize } = useFormItem({
+  size,
+})
+
 const emits = defineEmits(['update:modelValue', 'increase', 'decrease'])
 const isHovering = ref<boolean>(false)
 const limit = reactive({


### PR DESCRIPTION
input-number 组件中没有适配表单的尺寸，会导致步进按钮显示尺寸不对，简单修复了这个问题：
![image](https://github.com/ecaps1038/yike-design-dev/assets/29590076/f0b384a0-403b-4187-a850-4678866e4307)
 修复后⬇️
![image](https://github.com/ecaps1038/yike-design-dev/assets/29590076/c83d36a1-e845-46d1-81d0-0042053cef3a)

