### PR TITLE
fix: tooltip auto change position does not work will scroll to left or right

### DIFF
--- a/packages/yike-design-ui/src/components/tooltip/src/tooltip.vue
+++ b/packages/yike-design-ui/src/components/tooltip/src/tooltip.vue
@@ -95,7 +95,7 @@ const getPlacementClassName = computed(() => {
   ]
 
   if (autoAdjustOverflow.value) {
-    classNames.push(...placements)
+    classNames.push(placements.join(''))
   }
 
   return classNames


### PR DESCRIPTION
修复当滑动遮挡提示条左边或者右边时，提示条不改变位置。
fixes https://github.com/ecaps1038/yike-design-dev/issues/286