### PR TITLE
fix(demo): solving mobile document overflow

### DIFF
--- a/demo/src/components/DocPage.vue
+++ b/demo/src/components/DocPage.vue
@@ -68,7 +68,7 @@ onMounted(() => {
 
     .wrapper {
       padding: 0 16px;
-      width: 100vw;
+      width: 100%;
     }
 
     .anchor-wrap {

--- a/demo/src/components/TopBar.vue
+++ b/demo/src/components/TopBar.vue
@@ -79,12 +79,11 @@ const isDev = import.meta.env.DEV
   align-items: center;
   padding: 0 24px;
 
-  width: 100vw;
+  width: 100%;
   height: var(--top-bar-height);
   border-bottom: 1px solid @line-color-s;
   background-color: @bg-color-l;
   transition: all @animats;
-  box-sizing: border-box;
 
   a {
     display: flex;


### PR DESCRIPTION
修复：移动端（可视宽度 小于810px）时文档页面底部出现滚动