### PR TITLE
fix(input-tag): 修复tag高度问题以及收起tag数量错误问题

### DIFF
--- a/packages/yike-design-ui/src/components/input-tag/src/input-tag.vue
+++ b/packages/yike-design-ui/src/components/input-tag/src/input-tag.vue
@@ -38,7 +38,7 @@
               :class="bem('tag-list-item')"
               :disabled="mergedDisabled"
             >
-              +{{ tagList.length - +showCollapsedNum }}
+              +{{ tagList.length - +mincollapsedNum }}
             </yk-tag>
             <slot
               v-else

--- a/packages/yike-design-ui/src/components/input-tag/style/index.less
+++ b/packages/yike-design-ui/src/components/input-tag/style/index.less
@@ -31,7 +31,7 @@
     &--xl {
       .yk-tag {
         margin: 4px 4px 0px 0;
-        height: 38px;
+        min-height: 38px;
       }
       .yk-tag__content {
         font-size: @size-m;
@@ -40,7 +40,7 @@
     &--l {
       .yk-tag {
         margin: 3px 4px 1px 0;
-        height: 28px;
+        min-height: 28px;
       }
       .yk-tag__content {
         font-size: @size-s;
@@ -49,7 +49,7 @@
     &--m {
       .yk-tag {
         margin: 3px 4px 1px 0;
-        height: 24px;
+        min-height: 24px;
       }
       .yk-tag__content {
         font-size: @size-s;
@@ -58,7 +58,7 @@
     &--s {
       .yk-tag {
         margin: 2px 4px 1px 0;
-        height: 18px;
+        min-height: 18px;
       }
       .yk-tag__content {
         font-size: @size-ss;


### PR DESCRIPTION
修复以下问题：
1、当输入超过当前宽度需要换行的高度时，高度被限制住了，导致文本溢出。
2、当使用收起功能的时候，超出部分的数量计算有误。