### PR TITLE
fix(modal): should not trigger keydown event when modelValue is false

### DIFF
--- a/packages/yike-design-ui/components/modal/src/modal.vue
+++ b/packages/yike-design-ui/components/modal/src/modal.vue
@@ -118,7 +118,7 @@ onMounted(() => {
 })
 
 const escapeClose = (ev: KeyboardEvent) => {
-  if (ev.key === 'Escape') closeModal()
+  if (ev.key === 'Escape' && props.modelValue) closeModal()
 }
 const closeMaskToCloseModal = () => {
   props.closeable && emit('update:modelValue', false)


### PR DESCRIPTION
现在的情况是即使弹窗被关闭了，按下 esc 键也会触发 `onCloseModal` 事件