### PR TITLE
feat(base): add sub-path support

### DIFF
--- a/packages/yike-design-ui/package.json
+++ b/packages/yike-design-ui/package.json
@@ -23,6 +23,14 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "imports": {
+    "#comps": "./components",
+    "#utils": "./components/utils",
+    "#styles": "./components/styles",
+    "#comps/*": "./components/*",
+    "#utils/*": "./components/utils/*",
+    "#styles/*": "./components/styles/*"
+  },
   "files": [
     "es",
     "lib",

--- a/packages/yike-design-ui/tsconfig.json
+++ b/packages/yike-design-ui/tsconfig.json
@@ -4,7 +4,7 @@
     "jsx": "preserve",
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "lib": ["DOM", "ESNext"],
     "declaration": true,
     "skipLibCheck": true,
@@ -15,7 +15,15 @@
     "emitDeclarationOnly": true,
     "useDefineForClassFields": true,
     "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "#comps": ["./components"],
+      "#utils": ["./components/utils"],
+      "#styles": ["./components/styles"],
+      "#comps/*": ["./components/*"],
+      "#utils/*": ["./components/utils/*"],
+      "#styles/*": ["./components/styles/*"]
+    }
   },
   "exclude": ["dist", "es", "lib"]
 }


### PR DESCRIPTION
这个改动能够使路径导入更容易。

例如：

```ts
import { createCssScope } from '../../utils'
import YkSpinner from '../../spinner'
import '../../spinner/style';
```
可以把上面导入方式代替为：

```ts
import { createCssScope } from '#utils'
import YkSpinner from '#comps/spinner'
import '#comps/spinner/style';
```