### PR TITLE
fix(tree): resolve error of tree component

### DIFF
--- a/packages/yike-design-ui/components/tree/src/node-switcher.vue
+++ b/packages/yike-design-ui/components/tree/src/node-switcher.vue
@@ -6,6 +6,7 @@ import { TreeInjectionKey, TreeNodeInjectionKey } from './tree'
 const bem = createCssScope('tree-node-switcher')
 
 const nodeContext = inject(TreeNodeInjectionKey)
+
 const context = inject(TreeInjectionKey)
 </script>
 

--- a/packages/yike-design-ui/components/tree/src/tree.vue
+++ b/packages/yike-design-ui/components/tree/src/tree.vue
@@ -38,7 +38,7 @@ const props = withDefaults(defineProps<TreeProps>(), {
   blockNode: false,
   multiple: false,
   expandIcon() {
-    return h(IconRightFill)
+    return () => h(IconRightFill)
   },
   defaultExpandedKeys() {
     return []


### PR DESCRIPTION
属性```expandIcon```默认类型为```RenderFunction```，实际为 ``` expandIcon() {
    return h(IconRightFill)
  }```，即```VNode```类型，
在模版执行```<component :is="(context?.expandIcon?.() as any)" />```报错